### PR TITLE
match platforms and dependencies in Package.swift to info in podspec

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,13 +5,18 @@ import PackageDescription
 
 let package = Package(
     name: "TLDExtract",
+    platforms: [
+        .iOS(.v10),
+        .macOS(.v10_12),
+        .tvOS(.v11)
+    ],
     products: [
         .library(
             name: "TLDExtract",
             targets: ["TLDExtract"])
     ],
     dependencies: [
-        .package(url: "https://github.com/gumob/PunycodeSwift.git", .branch("master"))
+        .package(url: "https://github.com/gumob/PunycodeSwift.git", .upToNextMajor(from: "2.1.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
Without platforms, SPM makes some assumptions about what platforms and versions are supported.
Without a version on the Punycode dependency, SPM will force anyone who wants to use this library to target a branch or commit.

By matching the values in the podspec, you will allow people to consume this library in the same ways they can consume it with CocoaPods 